### PR TITLE
Fix: process only LF_MEMBER in fieldlist

### DIFF
--- a/drakpdb/type_info.py
+++ b/drakpdb/type_info.py
@@ -118,6 +118,7 @@ def process_structure(struct):
         {
             member.name: process_structure_member(member)
             for member in struct.fieldlist.substructs
+            if member.leaf_type == "LF_MEMBER"
         },
     ]
 


### PR DESCRIPTION
There are also other structures like `LF_METHODLIST` that are currently unsupported.